### PR TITLE
docs: fix canonical URL, add robots.txt and llms.txt

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://beyondthecloud.dev/',
+  url: 'https://sosl.beyondthecloud.dev',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,0 +1,48 @@
+# SOSL Lib
+
+> Apex library that provides functional constructs for building SOSL (Salesforce Object Search Language) queries in Salesforce. Open source (MIT), maintained by Beyond The Cloud as part of Apex Fluently.
+
+SOSL Lib wraps SOSL search queries in a fluent Apex builder: `SOSL.find('term').returning(SOSL.Returning(Account.SObject).with(Account.Id, Account.Name)).toSearchList()`. It covers FIND, RETURNING, WHERE, USING SCOPE, ORDER BY, LIMIT, OFFSET, field-level security, sharing mode and mocking of search results in unit tests.
+
+## Docs
+
+- [Getting Started](https://sosl.beyondthecloud.dev/): deploy to Salesforce, feature list, license notes
+- [Installation](https://sosl.beyondthecloud.dev/installation): how to add SOSL Lib to a Salesforce project
+- [Overview](https://sosl.beyondthecloud.dev/docs/overview): single class, functional style, dynamic SOSL, FLS, sharing, mocking, dynamic conditions
+- [Basic Features](https://sosl.beyondthecloud.dev/docs/basic-features): dynamic SOSL, controlling FLS, sharing mode, mocking, dynamic conditions with code samples
+- [Design](https://sosl.beyondthecloud.dev/design): single-class design (SOSL.cls) and functional programming approach
+
+## API
+
+- [SOSL](https://sosl.beyondthecloud.dev/api/sosl): main entry point, FIND clause, scope, limit, offset, sharing, mocking, result methods
+- [Returning](https://sosl.beyondthecloud.dev/api/sosl-returning): RETURNING clause per SObject, fields, filters, ordering, subqueries
+- [Filter](https://sosl.beyondthecloud.dev/api/sosl-filter): single WHERE condition on a field
+- [FilterGroup](https://sosl.beyondthecloud.dev/api/sosl-filters-group): grouping and combining filters with AND/OR
+
+## Examples
+
+- [FIND](https://sosl.beyondthecloud.dev/examples/find)
+- [SUBQUERY](https://sosl.beyondthecloud.dev/examples/subquery)
+- [USING SCOPE](https://sosl.beyondthecloud.dev/examples/scope)
+- [WHERE](https://sosl.beyondthecloud.dev/examples/where)
+- [GROUP BY](https://sosl.beyondthecloud.dev/examples/group-by)
+- [ORDER BY](https://sosl.beyondthecloud.dev/examples/order-by)
+- [LIMIT](https://sosl.beyondthecloud.dev/examples/limit)
+- [OFFSET](https://sosl.beyondthecloud.dev/examples/offset)
+- [FIELD-LEVEL SECURITY](https://sosl.beyondthecloud.dev/examples/fls)
+- [SHARING MODE](https://sosl.beyondthecloud.dev/examples/sharing-settings)
+- [MOCKING](https://sosl.beyondthecloud.dev/examples/mocking)
+- [DEBUGGING](https://sosl.beyondthecloud.dev/examples/debug)
+- [RESULT](https://sosl.beyondthecloud.dev/examples/result)
+
+## Advanced Usage
+
+- [Field-Level Security](https://sosl.beyondthecloud.dev/advanced-usage/fls): how FLS is enforced and how to bypass it
+- [Sharing Rules](https://sosl.beyondthecloud.dev/advanced-usage/sharing): with sharing, without sharing, inherited sharing
+- [Mocking](https://sosl.beyondthecloud.dev/advanced-usage/mocking): returning fake search results in Apex tests
+
+## Links
+
+- [Source code on GitHub](https://github.com/beyond-the-cloud-dev/sosl-lib)
+- [Apex Fluently](https://apexfluently.beyondthecloud.dev): the family of Apex libraries this project belongs to
+- [Beyond The Cloud](https://beyondthecloud.dev): Salesforce consultancy that maintains the library

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://sosl.beyondthecloud.dev/sitemap.xml


### PR DESCRIPTION
The docs site config had `url: 'https://beyondthecloud.dev/'`, so every page's canonical link and every sitemap entry pointed at the main company site instead of https://sosl.beyondthecloud.dev. The site also had no robots.txt (404 in production) and no llms.txt.

Changes in `website/`:

- `docusaurus.config.js`: `url` set to `https://sosl.beyondthecloud.dev`. Canonical tags and sitemap.xml now use the correct host.
- `static/robots.txt`: allow all, points at `/sitemap.xml`.
- `static/llms.txt`: hand-written index of the docs, API, examples and advanced pages with absolute links (Docusaurus 2.x, so no plugin).

Verified with `npm run build` in `website/`: build succeeds, `build/robots.txt` and `build/llms.txt` are emitted, canonical and sitemap use `sosl.beyondthecloud.dev`, and every link in llms.txt resolves to a built page.